### PR TITLE
CRYPTO-003: Fetch prices from external Binance & Huobi and store best price to Database

### DIFF
--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/connector/feignclient/HuobiPriceFeignClient.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/connector/feignclient/HuobiPriceFeignClient.java
@@ -12,4 +12,6 @@ public interface HuobiPriceFeignClient {
 
     @GetMapping(value = "/market/tickers")
     HuobiPairResponse fetchHuobiPair();
+
+    // TODO: Create a service to fetch and execute fetching logic
 }

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/controller/BaseController.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/controller/BaseController.java
@@ -2,6 +2,7 @@ package com.huytran.cryptotrading.cryptotradingsystem.controller;
 
 import com.huytran.cryptotrading.cryptotradingsystem.connector.feignclient.BinancePriceFeignClient;
 import com.huytran.cryptotrading.cryptotradingsystem.connector.feignclient.HuobiPriceFeignClient;
+import com.huytran.cryptotrading.cryptotradingsystem.service.AggregatedPriceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,12 +13,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class BaseController {
 
-    private final BinancePriceFeignClient binancePriceFeignClient;
-    private final HuobiPriceFeignClient huobiPriceFeignClient;
+    private final AggregatedPriceService aggregatedPriceService;
 
     @GetMapping("/prices/latest")
     public void fetchPrice() {
-        System.out.println("Binance Price: " + binancePriceFeignClient.fetchBinancePair());
-        System.out.println("Huobi Price: " + huobiPriceFeignClient.fetchHuobiPair());
+        aggregatedPriceService.aggregatePrice();
     }
 }

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/entity/AggregatedPrice.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/entity/AggregatedPrice.java
@@ -19,9 +19,5 @@ public class AggregatedPrice {
     private String pair;
     private Double bidPrice; // Best price to SELL
     private Double askPrice; // Best price to BUY
-
-    @Column(name = "timestamp")
-    private LocalDateTime timestamp;
-
-    // Constructors, Getters, and Setters
+    @Builder.Default private LocalDateTime timestamp = LocalDateTime.now();
 }

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/entity/CryptoUser.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/entity/CryptoUser.java
@@ -3,8 +3,6 @@ package com.huytran.cryptotrading.cryptotradingsystem.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.math.BigDecimal;
-
 @Getter
 @Setter
 @Builder
@@ -20,6 +18,6 @@ public class CryptoUser {
     private String username;
 
     @Column(name = "wallet_balance")
-    private Double walletBalance = 50000.0;
+    private Double walletBalance;
 }
 

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/enums/CryptoPair.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/enums/CryptoPair.java
@@ -1,0 +1,6 @@
+package com.huytran.cryptotrading.cryptotradingsystem.enums;
+
+public enum CryptoPair {
+    ETHUSDT,
+    BTCUSDT;
+}

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/repository/AggregatedPriceRepository.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/repository/AggregatedPriceRepository.java
@@ -1,0 +1,7 @@
+package com.huytran.cryptotrading.cryptotradingsystem.repository;
+
+import com.huytran.cryptotrading.cryptotradingsystem.entity.AggregatedPrice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AggregatedPriceRepository extends JpaRepository<AggregatedPrice, Long> {
+}

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/repository/BaseRepository.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/repository/BaseRepository.java
@@ -1,4 +1,0 @@
-package com.huytran.cryptotrading.cryptotradingsystem.repository;
-
-public interface BaseRepository {
-}

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/service/AggregatedPriceService.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/service/AggregatedPriceService.java
@@ -3,5 +3,7 @@ package com.huytran.cryptotrading.cryptotradingsystem.service;
 import org.springframework.stereotype.Service;
 
 @Service
-public class BaseServiceImpl implements BaseService {
+public interface AggregatedPriceService {
+
+    void aggregatePrice();
 }

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/service/AggregatedPriceServiceImpl.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/service/AggregatedPriceServiceImpl.java
@@ -1,0 +1,59 @@
+package com.huytran.cryptotrading.cryptotradingsystem.service;
+
+import com.huytran.cryptotrading.cryptotradingsystem.connector.feignclient.BinancePriceFeignClient;
+import com.huytran.cryptotrading.cryptotradingsystem.connector.feignclient.HuobiPriceFeignClient;
+import com.huytran.cryptotrading.cryptotradingsystem.entity.AggregatedPrice;
+import com.huytran.cryptotrading.cryptotradingsystem.enums.CryptoPair;
+import com.huytran.cryptotrading.cryptotradingsystem.repository.AggregatedPriceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class AggregatedPriceServiceImpl implements AggregatedPriceService {
+
+    private final BinancePriceFeignClient binancePriceFeignClient;
+    private final HuobiPriceFeignClient huobiPriceFeignClient;
+
+    private final AggregatedPriceRepository aggregatedPriceRepository;
+
+    @Override
+    public void aggregatePrice() {
+        // TODO: Extract logic to fetch Binance & Huobi with desired CryptoPair
+        final var binancePairs = binancePriceFeignClient.fetchBinancePair();
+        final var huobiPairs = huobiPriceFeignClient.fetchHuobiPair().getData();
+
+        final var aggregatedPrices = Stream.concat(
+                binancePairs.stream()
+                        .filter(binancePair -> CryptoPair.ETHUSDT.name().equalsIgnoreCase(binancePair.getSymbol())
+                                            || CryptoPair.BTCUSDT.name().equalsIgnoreCase(binancePair.getSymbol()))
+                        .map(binancePair -> AggregatedPrice.builder().pair(binancePair.getSymbol().toUpperCase()).bidPrice(binancePair.getBidPrice()).askPrice(binancePair.getAskPrice()).build()),
+                huobiPairs.stream()
+                        .filter(binancePair -> CryptoPair.ETHUSDT.name().equalsIgnoreCase(binancePair.getSymbol())
+                                || CryptoPair.BTCUSDT.name().equalsIgnoreCase(binancePair.getSymbol()))
+                        .map(binancePair -> AggregatedPrice.builder().pair(binancePair.getSymbol().toUpperCase()).bidPrice(binancePair.getBid()).askPrice(binancePair.getAsk()).build())
+                ).toList();
+
+        Map<String, AggregatedPrice> bestPrices = aggregatedPrices.stream()
+                .collect(Collectors.toMap(
+                   AggregatedPrice::getPair,
+                   p -> p,
+                   (p1 , p2) ->
+                       AggregatedPrice.builder()
+                               .pair(p1.getPair())
+                               .bidPrice(Math.max(p1.getBidPrice(), p2.getBidPrice()))
+                               .askPrice(Math.min(p1.getAskPrice(), p2.getAskPrice()))
+                               .build()
+
+                ));
+        bestPrices.values().forEach(this::saveToDb);
+    }
+
+    private void saveToDb(AggregatedPrice aggregatedPrice) {
+        aggregatedPriceRepository.save(aggregatedPrice);
+    }
+}

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/service/BaseService.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/service/BaseService.java
@@ -1,4 +1,0 @@
-package com.huytran.cryptotrading.cryptotradingsystem.service;
-
-public interface BaseService {
-}


### PR DESCRIPTION
### SUMMARY

- Regarding the requirement, it is required to fetch price data from the Binance and Huobi APIs and store the best pricing into the Database
- This PR is intended to implement the `AggregatedPriceService` to store the best pricing in the database after fetching price data from Binance and Huobi APIs.