### PR TITLE
CRYPTO-004: Configure scheduler and schedule price aggregation

### DIFF
--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/CryptoTradingSystemApplication.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/CryptoTradingSystemApplication.java
@@ -3,9 +3,11 @@ package com.huytran.cryptotrading.cryptotradingsystem;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableScheduling
 public class CryptoTradingSystemApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/config/SchedulerConfig.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/config/SchedulerConfig.java
@@ -1,0 +1,15 @@
+package com.huytran.cryptotrading.cryptotradingsystem.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "crypto-trading-system.config.scheduler")
+public class SchedulerConfig {
+
+    private long priceAggregationInterval;
+}

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/scheduler/Scheduler.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/scheduler/Scheduler.java
@@ -1,4 +1,18 @@
 package com.huytran.cryptotrading.cryptotradingsystem.scheduler;
 
+import com.huytran.cryptotrading.cryptotradingsystem.service.AggregatedPriceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
 public class Scheduler {
+
+    private final AggregatedPriceService aggregatedPriceService;
+
+    @Scheduled(fixedRateString = "#{schedulerConfig.priceAggregationInterval}") // SpEL expression
+    public void aggregatePrice() {
+        aggregatedPriceService.aggregatePrice();
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,3 +26,6 @@ spring.cloud.openfeign.client.config.default.logger-level=basic
 spring.cloud.openfeign.client.config.binanceFeignClient.url=https://api.binance.com
 spring.cloud.openfeign.client.config.huobiFeignClient.url=https://api.huobi.pro
 
+# Scheduler Configuration
+crypto-trading-system.config.scheduler.price-aggregation-interval=10000
+


### PR DESCRIPTION
### SUMMARY

- Regarding the requirement, it is required to fetch price data from the Binance and Huobi APIs every 10 seconds and aggregate the result.
- This PR is intended to do the following things:
  - Schedule to invoke price aggregation.
  - Dynamically configure scheduler settings.