### PR TITLE
CRYPTO-006: Implement API to get latest best price

### DIFF
--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/controller/PriceController.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/controller/PriceController.java
@@ -1,0 +1,28 @@
+package com.huytran.cryptotrading.cryptotradingsystem.controller;
+
+import com.huytran.cryptotrading.cryptotradingsystem.entity.AggregatedPrice;
+import com.huytran.cryptotrading.cryptotradingsystem.enums.Symbol;
+import com.huytran.cryptotrading.cryptotradingsystem.service.AggregatedPriceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/prices")
+@RequiredArgsConstructor
+public class PriceController {
+
+    private final AggregatedPriceService aggregatedPriceService;
+
+    @GetMapping("/latest")
+    public ResponseEntity<List<AggregatedPrice>> getLatestBestPrices() {
+        return ResponseEntity.ok(aggregatedPriceService.getLatestBestPriceForAllSymbols());
+    }
+
+    @GetMapping("/latest/{symbol}")
+    public ResponseEntity<AggregatedPrice> getLatestBestPrice(@PathVariable Symbol symbol) {
+        return ResponseEntity.ok(aggregatedPriceService.getLatestBestPriceForSymbol(symbol));
+    }
+}

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/model/response/LatestBestPrice.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/model/response/LatestBestPrice.java
@@ -1,0 +1,10 @@
+package com.huytran.cryptotrading.cryptotradingsystem.model.response;
+
+import lombok.Data;
+
+@Data
+public class LatestBestPrice {
+    private String symbol;
+    private Double bidPrice;
+    private Double askPrice;
+}

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/repository/AggregatedPriceRepository.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/repository/AggregatedPriceRepository.java
@@ -2,9 +2,22 @@ package com.huytran.cryptotrading.cryptotradingsystem.repository;
 
 import com.huytran.cryptotrading.cryptotradingsystem.entity.AggregatedPrice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AggregatedPriceRepository extends JpaRepository<AggregatedPrice, Long> {
     Optional<AggregatedPrice> findTop1AggregatedPriceBySymbolOrderByTimestampDesc(String symbol);
+
+    @Query(value = """
+        SELECT *
+        FROM aggregated_price
+        WHERE (symbol, timestamp) IN (
+            SELECT symbol, MAX(timestamp)
+            FROM aggregated_price
+            GROUP BY symbol
+        )
+    """, nativeQuery = true)
+    List<AggregatedPrice> findAllGroupedBySymbolOrderByTimestampDesc();
 }

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/service/AggregatedPriceService.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/service/AggregatedPriceService.java
@@ -1,9 +1,17 @@
 package com.huytran.cryptotrading.cryptotradingsystem.service;
 
+import com.huytran.cryptotrading.cryptotradingsystem.entity.AggregatedPrice;
+import com.huytran.cryptotrading.cryptotradingsystem.enums.Symbol;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public interface AggregatedPriceService {
 
     void aggregatePrice();
+
+    AggregatedPrice getLatestBestPriceForSymbol(Symbol symbol);
+
+    List<AggregatedPrice> getLatestBestPriceForAllSymbols();
 }

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/service/AggregatedPriceServiceImpl.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/service/AggregatedPriceServiceImpl.java
@@ -8,6 +8,7 @@ import com.huytran.cryptotrading.cryptotradingsystem.repository.AggregatedPriceR
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -51,6 +52,25 @@ public class AggregatedPriceServiceImpl implements AggregatedPriceService {
 
                 ));
         bestPrices.values().forEach(this::saveToDb);
+    }
+
+    @Override
+    public AggregatedPrice getLatestBestPriceForSymbol(Symbol symbol) {
+        final var latestBestPrice = aggregatedPriceRepository.findTop1AggregatedPriceBySymbolOrderByTimestampDesc(symbol.name());
+
+        if (latestBestPrice.isEmpty()) {
+            throw new RuntimeException("No aggregated price found for symbol: " + symbol);
+        }
+
+        return latestBestPrice.get();
+    }
+
+    /**
+     * @return
+     */
+    @Override
+    public List<AggregatedPrice> getLatestBestPriceForAllSymbols() {
+        return aggregatedPriceRepository.findAllGroupedBySymbolOrderByTimestampDesc();
     }
 
     private void saveToDb(AggregatedPrice aggregatedPrice) {


### PR DESCRIPTION
### SUMMARY

- Regarding the requirement, it is required to implement APIs to retrieve the latest best aggregated price.
- This PR is intended to implement two APIs:
  - `"/latest"`: retrieve the latest best aggregated price for all symbols.
  - `"/latest/{symbol}"`: retrieve the latest best aggregated price for a specific symbol.