### PR TITLE
CRYPTO-011: Implement get trade history

### DIFF
--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/controller/TradeController.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/controller/TradeController.java
@@ -1,26 +1,39 @@
 package com.huytran.cryptotrading.cryptotradingsystem.controller;
 
+import com.huytran.cryptotrading.cryptotradingsystem.mapper.TradeMapper;
 import com.huytran.cryptotrading.cryptotradingsystem.model.request.TradeRequest;
+import com.huytran.cryptotrading.cryptotradingsystem.model.response.TradeHistoryResponse;
 import com.huytran.cryptotrading.cryptotradingsystem.model.response.TradeResponse;
 import com.huytran.cryptotrading.cryptotradingsystem.service.TradeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/trades")
 @RequiredArgsConstructor
 public class TradeController {
 
+    private static final Long DEFAULT_USER_ID = 1L;
+
+    private final TradeMapper tradeMapper;
     private final TradeService tradeService;
 
     @PostMapping
     public ResponseEntity<TradeResponse> trade(@RequestBody TradeRequest tradeRequest) {
+        tradeRequest.setCryptoUserId(DEFAULT_USER_ID);
         final var tradeResponse = tradeService.executeTrade(tradeRequest);
 
         return ResponseEntity.ok(tradeResponse);
+    }
+
+    @GetMapping("/history")
+    public ResponseEntity<List<TradeHistoryResponse>> getTradeHistory() {
+        final var tradeHistory = tradeService.getTradeHistoryByUserId(DEFAULT_USER_ID);
+        final var response = tradeMapper.toResponse(tradeHistory);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/mapper/TradeMapper.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/mapper/TradeMapper.java
@@ -1,0 +1,16 @@
+package com.huytran.cryptotrading.cryptotradingsystem.mapper;
+
+import com.huytran.cryptotrading.cryptotradingsystem.entity.Transaction;
+import com.huytran.cryptotrading.cryptotradingsystem.model.response.TradeHistoryResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+
+import java.util.List;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface TradeMapper {
+
+    TradeHistoryResponse toResponse(Transaction transaction);
+
+    List<TradeHistoryResponse> toResponse(List<Transaction> transaction);
+}

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/model/response/TradeHistoryResponse.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/model/response/TradeHistoryResponse.java
@@ -1,0 +1,24 @@
+package com.huytran.cryptotrading.cryptotradingsystem.model.response;
+
+import com.huytran.cryptotrading.cryptotradingsystem.enums.TradeType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TradeHistoryResponse {
+    private String symbol;
+    private TradeType type;
+    private double price;
+    private double quantity;
+    private double total;
+    private LocalDateTime timestamp;
+
+    public double getTotal() {
+        return price * quantity;
+    }
+}

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/repository/TransactionRepository.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/repository/TransactionRepository.java
@@ -3,5 +3,9 @@ package com.huytran.cryptotrading.cryptotradingsystem.repository;
 import com.huytran.cryptotrading.cryptotradingsystem.entity.Transaction;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TransactionRepository extends JpaRepository<Transaction, Long> {
+
+    List<Transaction> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/service/TradeService.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/service/TradeService.java
@@ -1,9 +1,14 @@
 package com.huytran.cryptotrading.cryptotradingsystem.service;
 
+import com.huytran.cryptotrading.cryptotradingsystem.entity.Transaction;
 import com.huytran.cryptotrading.cryptotradingsystem.model.request.TradeRequest;
 import com.huytran.cryptotrading.cryptotradingsystem.model.response.TradeResponse;
+
+import java.util.List;
 
 public interface TradeService {
 
     TradeResponse executeTrade(TradeRequest tradeRequest);
+
+    List<Transaction> getTradeHistoryByUserId(Long userId);
 }

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/service/TradeServiceImpl.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/service/TradeServiceImpl.java
@@ -1,11 +1,14 @@
 package com.huytran.cryptotrading.cryptotradingsystem.service;
 
+import com.huytran.cryptotrading.cryptotradingsystem.entity.Transaction;
 import com.huytran.cryptotrading.cryptotradingsystem.enums.TradeType;
 import com.huytran.cryptotrading.cryptotradingsystem.model.request.TradeRequest;
 import com.huytran.cryptotrading.cryptotradingsystem.model.response.TradeResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +38,11 @@ public class TradeServiceImpl implements TradeService {
         }
 
         return new TradeResponse(tradeRequest.getSymbol(), tradeRequest.getTradeType(), tradeRequest.getQuantity(), tradePrice);
+    }
+
+    @Override
+    public List<Transaction> getTradeHistoryByUserId(Long userId) {
+        return transactionService.getAllTransactionsByUserId(userId);
     }
 
     private double getTradePrice(TradeRequest tradeRequest) {

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/service/TransactionService.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/service/TransactionService.java
@@ -2,7 +2,11 @@ package com.huytran.cryptotrading.cryptotradingsystem.service;
 
 import com.huytran.cryptotrading.cryptotradingsystem.entity.Transaction;
 
+import java.util.List;
+
 public interface TransactionService {
 
     Transaction createTransaction(Transaction transaction);
+
+    List<Transaction> getAllTransactionsByUserId(Long userId);
 }

--- a/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/service/TransactionServiceImpl.java
+++ b/src/main/java/com/huytran/cryptotrading/cryptotradingsystem/service/TransactionServiceImpl.java
@@ -5,6 +5,8 @@ import com.huytran.cryptotrading.cryptotradingsystem.repository.TransactionRepos
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class TransactionServiceImpl implements TransactionService {
@@ -14,5 +16,10 @@ public class TransactionServiceImpl implements TransactionService {
     @Override
     public Transaction createTransaction(Transaction transaction) {
         return transactionRepository.save(transaction);
+    }
+
+    @Override
+    public List<Transaction> getAllTransactionsByUserId(Long userId) {
+        return transactionRepository.findAllByUserId(userId);
     }
 }


### PR DESCRIPTION
### SUMMARY
- Regarding the requirement, it is required that user can retrieve their trade histories.
- This PR is intended to implement an API with endpoint `"/trades/history"` to retrieve user's trade histories.